### PR TITLE
__callStatic: cache created Enum instances

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -227,7 +227,8 @@ abstract class Enum implements \JsonSerializable
         if (!isset(self::$instances[$class][$name])) {
             $array = static::toArray();
             if (!isset($array[$name]) && !\array_key_exists($name, $array)) {
-                throw new \BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
+                $message = "No static method or enum constant '$name' in class " . static::class;
+                throw new \BadMethodCallException($message);
             }
             return self::$instances[$class][$name] = new static($array[$name]);
         }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -38,6 +38,14 @@ abstract class Enum implements \JsonSerializable
     protected static $cache = [];
 
     /**
+     * Cache of instances of the Enum class
+     *
+     * @var array
+     * @psalm-var array<class-string, array<string, static>>
+     */
+    protected static $instances = [];
+
+    /**
      * Creates a new value of some type
      *
      * @psalm-pure
@@ -211,17 +219,19 @@ abstract class Enum implements \JsonSerializable
      * @param array  $arguments
      *
      * @return static
-     * @psalm-pure
      * @throws \BadMethodCallException
      */
     public static function __callStatic($name, $arguments)
     {
-        $array = static::toArray();
-        if (isset($array[$name]) || \array_key_exists($name, $array)) {
-            return new static($array[$name]);
+        $class = static::class;
+        if (!isset(self::$instances[$class][$name])) {
+            $array = static::toArray();
+            if (!isset($array[$name]) && !\array_key_exists($name, $array)) {
+                throw new \BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
+            }
+            return self::$instances[$class][$name] = new static($array[$name]);
         }
-
-        throw new \BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
+        return self::$instances[$class][$name];
     }
 
     /**


### PR DESCRIPTION
Instead of creating a new one each time, cache them.

This only matters if you're creating thousands of these objects.

I've used a small test script:

    <?
    require './vendor/autoload.php';

    class Fast extends MyCLabs\Enum\Enum {
       protected const VALUE_ONE = "one";
       protected const VALUE_TWO = "two";
    }

    $t = microtime(true);
    for ($i = 0; $i < 1000; $i++) {
       Fast::VALUE_ONE();
    }
    $secondsPerOp = (microtime(true) - $t) / 1000;
    var_dump("Microseconds per op: " . $secondsPerOp * 1000000);

Before this change, we were getting about 4us per operation,
after this, we get about 1us per op, a 4X speedup!!

Note: This only matters if you end up constructing thousands of these
objects. We end up using this library extensively and thus end up
incurring more than ten milliseconds per request just for Enum
construction.